### PR TITLE
Update docker compose version to v2

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: run containers
         run: |
-          docker-compose -f "docker-compose-dev.yml" up -d --build
+          docker compose -f "docker-compose-dev.yml" up -d --build
 
       - name: setup golang
         uses: actions/setup-go@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: stop containers
         run: |
-          docker-compose -f "docker-compose-dev.yml" down
+          docker compose -f "docker-compose-dev.yml" down
 
   upload_image:
 #    if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/master') }}


### PR DESCRIPTION
- Github deprecated `docker-compose`
- This PR is updating the workflow to use `docker compose` (removing the dash)